### PR TITLE
Add statsLogPipe: slapd operation latency histograms from a named pipe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,95 @@
+# End to end test of the statsLogPipe latency path against a real slapd.
+#
+# slapd runs as a service container from the stock bitnami OpenLDAP image,
+# configured entirely through environment variables.  The job container and
+# the service share the openldap_stats docker volume, mounted at /stats in
+# both, which carries the named pipe (FIFO).  The test starts the exporter,
+# which holds the pipe's read end, then points the running slapd at the pipe
+# by setting olcLogFile through the cn=config admin, and generates traffic
+# over the service network at ldap://openldap:389.
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  logging:
+    timeout-minutes: 20
+    runs-on: self-hosted
+    container:
+      image: docker.internal.networkradius.com/self-hosted
+      options: >-
+        --memory-swap -1
+      volumes:
+        - openldap_stats:/stats
+    defaults:
+      run:
+        shell: bash
+    services:
+      openldap:
+        image: bitnamilegacy/openldap:latest
+        env:
+          LDAP_PORT_NUMBER: 389
+          LDAP_ROOT: dc=example,dc=org
+          LDAP_ADMIN_USERNAME: admin
+          LDAP_ADMIN_PASSWORD: secret
+          # cn=admin,cn=config lets the test set olcLogFile on the running server
+          LDAP_CONFIG_ADMIN_ENABLED: yes
+          LDAP_CONFIG_ADMIN_USERNAME: admin
+          LDAP_CONFIG_ADMIN_PASSWORD: secret
+          # Empty database: the test seeds its own entries and asserts counts
+          LDAP_SKIP_DEFAULT_TREE: yes
+          # The unknown-suffix check searches the root DSE anonymously
+          LDAP_ALLOW_ANON_BINDING: yes
+          # 256 is the stats debug mask; bitnami passes it to slapd -d, and
+          # the logfile slapd opens on olcLogFile carries the debug stream
+          LDAP_LOGLEVEL: 256
+        volumes:
+          - openldap_stats:/stats
+
+    steps:
+      - name: Mark the complete directory hierarchy as safe
+        run: git config --global --add safe.directory '*'
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install python build dependencies
+        run: |
+          sudo apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            python3 \
+            python3-venv \
+            python3-dev \
+            build-essential \
+            libldap2-dev \
+            libsasl2-dev
+
+      - name: Install the exporter into a venv
+        run: |
+          python3 -m venv venv
+          ./venv/bin/pip install --quiet .
+
+      - name: Create the stats pipe in the shared volume
+        # The volume persists on the runner host between jobs, so clear any
+        # stale pipe first.  Mode 666: bitnami's slapd runs as uid 1001 and
+        # must be able to open the pipe for writing.
+        run: |
+          rm -f /stats/stats.pipe
+          mkfifo -m 666 /stats/stats.pipe
+
+      - name: Run the logging test
+        run: ./venv/bin/python -m unittest discover -s tests/integration/statsLog -v
+
+      - name: On Failure - Dump exporter log
+        run: cat tests/integration/statsLog/run/exporter.log
+        if: ${{ github.ref != 'refs/heads/ci-debug' && failure() }}
+
+      - name: "On Failure - Start tmate"
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
+        if: ${{ github.ref == 'refs/heads/ci-debug' && failure() }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -36,3 +36,8 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      # python -m puts the checkout on sys.path so the package imports.
+      # tests/integration needs the slapd container, CI workflow only
+      run: |
+        python -m pytest tests -v --ignore=tests/integration

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+.pytest_cache/
+venv/
+*.egg-info/
+build/
+dist/
+tests/integration/statsLog/run/

--- a/README.md
+++ b/README.md
@@ -270,6 +270,113 @@ Statistics are tagged with the base DN and the `rid` of the provider.  In a mult
 cluster, for each `reportServers` entry there will be one statistic recorded for each
 provider in the cluster tagged with the appropriate `rid`.
 
+### statsLogPipe: operation latency over a stats pipe
+The monitoring database (cn=Monitor) only exposes operation counters, so polling it can
+never give latency.  slapd does log latency: every completed operation writes one RESULT
+line to the stats log carrying `qtime` (time the operation sat queued before a worker
+thread picked it up) and `etime` (wall clock time from receipt of the operation until
+its result was sent).  Both timers start when slapd reads the operation off the
+network, so `etime` includes `qtime`.
+
+The `statsLogPipe` key makes this service read those lines from a named pipe (FIFO, a file
+that passes data directly from a writing program to a reading one without storing it) and
+publish them as latency histograms on the Prometheus metrics page: `qtime` appears as
+`openldap_queue_latency_seconds` and `etime` as `openldap_operation_latency_seconds`,
+labelled with `database` and `operation` (bind, search, modify, add, delete, modrdn,
+compare, extended, disconnect).  The timing data never touches disk.
+
+These two histograms are recorded directly into the Prometheus client library rather
+than through OpenCensus, because a busy slapd can produce hundreds of thousands of log
+lines per second and OpenCensus recording tops out around ten thousand per second.  A
+reader that cannot keep up fills the pipe and stalls slapd's worker threads.  The
+consequence: the latency histograms only appear on the Prometheus metrics page, never
+through the Stackdriver exporter.
+
+An example, on the server entry it applies to:
+```yaml
+ldapServers:
+  - database: ldap1
+    connection:
+      serverUri: ldapi:///
+    statsLogPipe: /run/openldap/stats
+```
+
+#### Labelling latency by directory suffix
+The RESULT line does not name a database, but every operation first logs a request line
+carrying the target distinguished name (DN) under the same `conn=`/`op=` identifiers.
+When `statsLogPipe` is given as a mapping with a `suffixes` list, the reader remembers the
+DN of each in-flight operation and labels the timing with the longest configured suffix
+the DN falls under:
+```yaml
+    statsLogPipe:
+      pipe: /run/openldap/stats
+      suffixes:
+        - dc=example,dc=org
+        - cn=accesslog
+```
+Timings that cannot be attributed get `suffix="unknown"`: extended operations (their
+request line carries no DN), and operations already in flight when the reader started.
+Without a `suffixes` list the label is empty and no request tracking happens.
+Completed operations release their entry immediately: the result pops it, and the
+connection close drops all of a connection's entries.  Operations that never
+complete (abandons, persistent searches) are reclaimed by an hourly two pass
+sweep: an entry survives the first sweep after it was recorded and is freed by
+the second, so it lives at least one hour and at most two.  An operation that
+outlives its entry is still counted when a result finally arrives, labelled
+`suffix="unknown"`.
+
+How the pieces connect:
+1. Something creates the FIFO before slapd starts, for example a systemd drop-in on the
+   slapd unit with `ExecStartPre=/usr/bin/mkfifo /run/openldap/stats` (the same wiring the
+   openldap-audit2json deployment uses for the audit log pipe).
+2. This service starts and holds the read end of the FIFO open.  slapd cannot finish
+   opening the write end until a reader exists, so this service must be running first.
+3. slapd is told to write its log to the FIFO, and to send the stats category there.
+4. Each RESULT line slapd writes is parsed and recorded, and the exporters publish the
+   histograms.
+
+The slapd side needs three settings.  The first two are persistent (cn=config):
+```ldif
+dn: cn=config
+changetype: modify
+replace: olcLogLevel
+olcLogLevel: stats
+-
+replace: olcLogFile
+olcLogFile: /run/openldap/stats
+-
+replace: olcLogFileFormat
+olcLogFileFormat: syslog-utc
+```
+`olcLogLevel` controls what slapd sends to syslog.  `stats` keeps syslog behaving as a
+default slapd does.  Do NOT set `olcLogFileOnly`: that would turn syslog off entirely.
+Do NOT set `olcLogFileRotate`: rotation renames the log path, which must never happen to
+a FIFO.
+
+The third setting routes the stats category to the logfile and must be re-applied after
+every slapd restart (cn=Monitor settings are not persistent), for example from an
+`ExecStartPost` on the slapd unit:
+```ldif
+dn: cn=Log,cn=Monitor
+changetype: modify
+replace: monitorDebugLevel
+monitorDebugLevel: stats
+```
+Alternatively, start slapd with `-d stats` to make the routing persistent.  Note that
+`-d` also stops slapd detaching from the terminal, so the service unit must expect a
+foreground process.
+
+Failure behaviour: slapd ignores SIGPIPE and discards logging write errors, so if this
+service stops, slapd keeps running and only the metrics are lost.  If slapd stops, this
+service keeps the pipe open and picks up again when slapd returns.
+
+Known gaps in the data, inherent to slapd's stats log:
+- Abandoned operations never log a RESULT line, so operations the client gave up on are
+  missing from the histograms.  The slowest queries are exactly the ones most likely to
+  be abandoned; compare the cn=Monitor initiated/completed counters to see the gap.
+- Unbind and Abandon carry no timing.
+- A search returning many entries logs one line whose etime covers the entire search.
+
 ## Credits
 Copyright 2023, NetworkRADIUS 
 This utility was written by Mark Donnelly, mark - at - painless-securtiy - dot - com.

--- a/openldap-opencensus-stats.template.yml
+++ b/openldap-opencensus-stats.template.yml
@@ -6,6 +6,15 @@ ldapServers:
       userPassword: password
       startTls: false
       timeout: 5
+    # Optional: read slapd qtime/etime stats lines from this named pipe and
+    # publish latency histograms.  See README "Operation latency over a stats pipe".
+    # Short form:  statsLogPipe: /run/openldap/stats
+    # With suffixes, latency is additionally labelled by directory suffix:
+    statsLogPipe:
+      pipe: /run/openldap/stats
+      suffixes:
+        - dc=example,dc=org
+        - cn=accesslog
   - database: ldap2
     connection:
       serverUri: ldap://ldap2.example.org/

--- a/openldap_opencensus_stats/config_transformers/child_object.py
+++ b/openldap_opencensus_stats/config_transformers/child_object.py
@@ -16,9 +16,11 @@ class ChildObjectConfigurationTransformer(ConfigurationTransformer):
         config = copy.deepcopy(configuration)
         for server_config in config.get('ldap_servers'):
             ldap_server = ChildObjectConfigurationTransformer.get_ldap_server(server_config)
-            if not server_config.get('sync_only', False):
+            # A server entry with no object tree defines no cn=Monitor
+            # metrics (e.g. statsLogPipe only) and has nothing to transform
+            if not server_config.get('sync_only', False) and server_config.get('object'):
                 server_config['object'] = ChildObjectConfigurationTransformer.process_objects_for_ldap_server(
-                    configuration=server_config.get('object', {}),
+                    configuration=server_config.get('object'),
                     dn='',
                     ldap_server=ldap_server
                 )

--- a/openldap_opencensus_stats/configuration.py
+++ b/openldap_opencensus_stats/configuration.py
@@ -10,6 +10,7 @@ from openldap_opencensus_stats.ldap_metric_set import MetricSet
 from openldap_opencensus_stats.sync_metric_set import SyncMetricSet
 from openldap_opencensus_stats.ldap_server import LdapServerPool
 from openldap_opencensus_stats.ldap_statistic import LdapStatistic
+from openldap_opencensus_stats.ldap_stats_log_pipe import LdapStatsLogPipeReader, METRICS_NAMESPACE_DEFAULT
 
 from opencensus.stats import stats
 from opencensus.ext.prometheus import stats_exporter
@@ -31,6 +32,7 @@ class Configuration:
         self._sleep_time = 5
         self._metric_sets = []
         self._ldap_metrics = {}
+        self._stats_log_pipe_readers = []
 
         self.reconfigure()
 
@@ -45,14 +47,29 @@ class Configuration:
         if log_config and isinstance(log_config, dict):
             log_config['version'] = log_config.get('version', 1)
             logging.config.dictConfig(log_config)
+        prometheus_namespace = METRICS_NAMESPACE_DEFAULT
         for exporter_config in normalized_configuration.get('exporters', []):
             exporter = create_exporter(exporter_config)
             stats.stats.view_manager.register_exporter(exporter)
+            if exporter_config.get('name') == 'Prometheus':
+                prometheus_namespace = exporter.options.namespace
 
         for ldap_server_config in normalized_configuration.get('ldap_servers', []):
             if not ldap_server_config.get('sync_only', False):
                 metric_set = self.generate_metric_set(ldap_server_config)
                 self._metric_sets.append(metric_set)
+            stats_log_pipe = ldap_server_config.get('stats_log_pipe')
+            if stats_log_pipe:
+                if isinstance(stats_log_pipe, str):
+                    stats_log_pipe = {'pipe': stats_log_pipe}
+                stats_log_pipe_reader = LdapStatsLogPipeReader(
+                    database=ldap_server_config.get('database'),
+                    pipe_path=stats_log_pipe.get('pipe'),
+                    suffixes=stats_log_pipe.get('suffixes'),
+                    namespace=prometheus_namespace
+                )
+                stats_log_pipe_reader.start()
+                self._stats_log_pipe_readers.append(stats_log_pipe_reader)
 
         for base_dn, sync_config in normalized_configuration.get('sync', {}).items():
             ldap_server_names = sync_config.get('cluster_servers', [])
@@ -139,7 +156,7 @@ def create_exporter(exporter_configuration=None):
         if 'options' not in exporter_configuration:
             logging.error("The Prometheus exporter requires options configuration.")
             raise ValueError("The Prometheus exporter requires options configuration.")
-        final_options = {'namespace': 'openldap', 'port': 8000, 'address': '0.0.0.0'}
+        final_options = {'namespace': METRICS_NAMESPACE_DEFAULT, 'port': 8000, 'address': '0.0.0.0'}
         final_options.update(options)
         exporter = stats_exporter.new_stats_exporter(
             stats_exporter.Options(**final_options)

--- a/openldap_opencensus_stats/ldap_stats_log_pipe.py
+++ b/openldap_opencensus_stats/ldap_stats_log_pipe.py
@@ -1,0 +1,509 @@
+# openldap_opencensus_stats
+# Copyright (C) 2026  InkBridge Networks
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Read slapd operation timing from a named pipe and publish latency histograms.
+
+slapd writes one RESULT line to its stats log for every completed LDAP
+operation.  Each line carries two timings (enabled by default via
+SLAP_STATS_ETIME):
+
+    conn=1001 op=2 SEARCH RESULT tag=101 err=0 qtime=0.000012 etime=0.001234 nentries=5 text=
+
+1. qtime is how long the operation sat in slapd's thread pool queue before a
+   worker thread picked it up.
+2. etime is the wall clock time from receipt of the operation until its
+   result was sent.  Both timers start at receipt, so etime includes qtime;
+   execution time alone is etime minus qtime.
+
+The monitoring database (cn=Monitor) only exposes operation counters, so these
+log lines are the only latency data slapd produces.  To keep the data off
+disk, slapd's logfile is pointed at a named pipe (FIFO).  This module reads
+the pipe and records each timing into Prometheus histograms, served on the
+same metrics page as the existing cn=Monitor statistics.  The recording
+deliberately bypasses OpenCensus, so a busy server cannot outrun the reader;
+the register_metrics header explains the cost difference and the consequence
+(Prometheus only, the Stackdriver exporter never sees these two metrics).
+The metric names spell the abbreviations out: qtime is published as
+queue_latency_seconds and etime as operation_latency_seconds.
+
+The pipe handling:
+
+1. The pipe is opened O_RDWR|O_NONBLOCK.  Holding our own write end means
+   reads never return end of file when slapd restarts, so one descriptor
+   survives any number of writer turnovers.  Read-write FIFO opens are
+   Linux-defined behaviour, see fifo(7).  slapd's own open of the write end
+   blocks until a reader exists, so this service must be running first, and
+   must never block waiting for slapd.
+2. The event loop polls the descriptor (loop.add_reader) and drains the pipe
+   whenever data arrives.  Data moving through a pipe is not a filesystem
+   event, so an inotify/watchfiles monitor cannot see writes.  (The
+   openldap-audit2json PipeReader can watch the path because the auditlog
+   overlay opens and closes its log file around every entry; slapd opens its
+   stats logfile once and holds it.)
+3. A watchfiles monitor on the pipe's directory handles lifecycle only: the
+   pipe appearing triggers an open, deletion triggers a close.
+
+slapd ignores SIGPIPE and discards logging write errors, so stopping this
+service only ever costs metrics, never the directory server.
+
+To enable, add a statsLogPipe key naming the FIFO to an ldapServers entry, and
+point slapd's logfile at the same FIFO.  The README section "Operation
+latency over a stats pipe" walks through the slapd side.
+
+Optionally, statsLogPipe can list the directory suffixes to label latency by.
+The RESULT line does not name a database, but the request line each operation
+logs first does carry the target distinguished name (DN), under the same
+conn=/op= prefix:
+
+    conn=1001 op=2 SRCH base="dc=example,dc=org" scope=2 deref=0 filter="(uid=bob)"
+    conn=1001 op=2 SEARCH RESULT tag=101 err=0 qtime=... etime=...
+
+The reader remembers the DN per (conn, op), and when the matching RESULT
+arrives it labels the timing with the longest configured suffix the DN falls
+under.  Results whose DN was never seen or matches no configured suffix are
+labelled "unknown" (extended operations log no DN, and operations already in
+flight when the reader starts have no remembered request line).  Completed
+operations reclaim their mapping immediately: the matching RESULT pops it, and
+slapd logging the connection close drops all of a connection's mappings.  For
+operations that never complete (abandons, persistent searches), an hourly two
+pass sweep on the reader's event loop frees mappings born before the previous
+sweep, so those live at least one hour and at most two, and cannot
+accumulate.  With no suffixes configured the label is empty and no request
+tracking happens.
+"""
+import asyncio
+import logging
+import os
+import re
+import stat
+import threading
+
+from pathlib import Path
+
+from watchfiles import awatch, Change
+
+from prometheus_client import Histogram
+
+# Result tag values from the LDAP protocol, per
+# https://github.com/openldap/openldap/blob/45c7590378c60120e9ba3295ba1f223ceffa1de9/include/ldap.h#L536-L547
+TAG_TO_OPERATION = {
+    97: 'bind',
+    101: 'search',
+    103: 'modify',
+    105: 'add',
+    107: 'delete',
+    109: 'modrdn',
+    111: 'compare',
+    120: 'extended',
+}
+
+# Extended operation results carry oid= where every other result carries tag=
+RESULT_LINE_RE = re.compile(
+    r'(?:tag=(?P<tag>\d+)|oid=(?P<oid>\S*)) err=-?\d+ '
+    r'qtime=(?P<qtime>\d+\.\d+) etime=(?P<etime>\d+\.\d+)'
+)
+
+# The DN-bearing request lines: SRCH base="..." plus dn="..." for the others.
+# Extended operations (EXT oid=...) carry no DN and stay unmatched on purpose.
+REQUEST_LINE_RE = re.compile(
+    r'conn=(?P<conn>\d+) op=(?P<op>\d+) '
+    r'(?:SRCH base|(?:BIND|ADD|MOD|MODRDN|DEL|CMP) dn)="(?P<dn>[^"]*)"'
+)
+
+CONN_OP_RE = re.compile(r'conn=(?P<conn>-?\d+) op=(?P<op>\d+) ')
+
+CONN_CLOSED_RE = re.compile(r'conn=(?P<conn>\d+) fd=-?\d+ closed')
+
+SUFFIX_UNKNOWN = 'unknown'
+
+# Bounds on the (conn, op) -> DN table, tripped only if close lines go missing
+TRACKED_CONNECTIONS_MAX = 16384
+TRACKED_OPERATIONS_PER_CONNECTION_MAX = 4096
+
+# Completed operations reclaim their mapping immediately (the RESULT pops it,
+# the connection close drops it).  The two pass timer sweep only reclaims
+# mappings for operations that never complete (abandons, persistent searches):
+# a mapping survives the first sweep after it was tracked and is freed by the
+# second, so it lives at least one sweep interval and at most two.  An
+# operation that outlives its mapping is still counted when a RESULT finally
+# arrives, labelled suffix="unknown".
+TRACKED_REQUEST_SWEEP_SECONDS = 3600
+
+# slapd reports with microsecond resolution; the low edges capture healthy
+# operations (queue latency is normally single-digit microseconds)
+LATENCY_BUCKETS_SECONDS = [
+    0.00001, 0.000025, 0.00005, 0.0001, 0.00025, 0.0005,
+    0.001, 0.0025, 0.005, 0.01, 0.025, 0.05,
+    0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+]
+
+READ_CHUNK_BYTES = 65536
+
+METRICS_NAMESPACE_DEFAULT = 'openldap'
+
+METRICS_LABEL_NAMES = ('database', 'operation', 'suffix')
+
+_queue_latency_histogram = None
+_operation_latency_histogram = None
+
+
+def register_metrics(namespace=METRICS_NAMESPACE_DEFAULT) -> tuple:
+    """Create the two latency histograms, once per process.
+
+    The histograms go straight to the prometheus_client library, not
+    through OpenCensus: OpenCensus deep-copies its entire accumulated view
+    state on every single recording (~100us per log line, worse as label
+    combinations accumulate), while a direct histogram observation is a
+    couple of additions (~1us).  A busy slapd produces tens of thousands
+    of result lines per second, and a reader that cannot keep up fills the
+    pipe and stalls slapd's worker threads.  The trade: prometheus_client
+    metrics only exist on the Prometheus metrics page, so the Stackdriver
+    exporter never sees these two histograms.
+
+    prometheus_client serves whatever is on its default registry, and the
+    Prometheus exporter this service starts serves exactly that registry,
+    so the histograms appear next to the cn=Monitor statistics with no
+    extra wiring.  Every reader calls in, so a module guard makes the
+    second and later calls return the histograms already made.
+    """
+    global _queue_latency_histogram, _operation_latency_histogram
+
+    if _queue_latency_histogram is None:
+        _queue_latency_histogram = Histogram(
+            'queue_latency_seconds',
+            'Time an operation spent queued before a worker thread picked it up '
+            '(qtime in the slapd stats log)',
+            namespace=namespace,
+            labelnames=METRICS_LABEL_NAMES,
+            buckets=LATENCY_BUCKETS_SECONDS,
+        )
+        _operation_latency_histogram = Histogram(
+            'operation_latency_seconds',
+            'Wall clock time from receipt of the operation until its result was sent, '
+            'includes queue latency (etime in the slapd stats log)',
+            namespace=namespace,
+            labelnames=METRICS_LABEL_NAMES,
+            buckets=LATENCY_BUCKETS_SECONDS,
+        )
+
+    return _queue_latency_histogram, _operation_latency_histogram
+
+
+def normalize_dn(dn):
+    """Lowercase a DN and strip spaces after commas, so comparisons match."""
+    return re.sub(r',\s+', ',', dn.strip().lower())
+
+
+def len_of_normalized(suffix_pair):
+    """Sort key: the normalized DN's length in a (normalized, display) pair."""
+    return len(suffix_pair[0])
+
+
+class LdapStatsLogPipeReader:
+    def __init__(self, database=None, pipe_path=None, suffixes=None,
+                 namespace=METRICS_NAMESPACE_DEFAULT):
+        if database is None:
+            raise ValueError('LdapStatsLogPipeReader requires the database name for metric labelling')
+        if pipe_path is None:
+            raise ValueError('LdapStatsLogPipeReader requires the path of the pipe to read')
+
+        self.database = database
+        self.pipe_path = pipe_path
+        # longest suffix first, so nested suffixes match their deepest entry
+        self.suffixes = sorted(
+            [(normalize_dn(suffix), suffix) for suffix in (suffixes or [])],
+            key=len_of_normalized, reverse=True
+        )
+        self.queue_histogram, self.operation_histogram = register_metrics(namespace)
+
+        self.source_fd: int = None
+        self.buffer: bytes = b''
+        self.thread: threading.Thread = None
+        self.loop: asyncio.AbstractEventLoop = None
+        self.stop_event: asyncio.Event = None
+        self.request_dn_table: dict = {}
+        self.sweep_generation: int = 0
+        self.latency_child_table: dict = {}
+
+    def start(self) -> None:
+        """Start reading the pipe on a background thread.
+
+        The thread runs its own event loop, so the exporter's LDAP polling
+        loop is never held up by pipe work.
+        """
+        self.thread = threading.Thread(
+            target=self.run,
+            name=f'stats-pipe-{self.database}',
+            daemon=True
+        )
+        self.thread.start()
+
+    def run(self) -> None:
+        """The background thread's body: read the pipe until stop() is called."""
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
+        self.stop_event = asyncio.Event()
+        if self.suffixes:
+            self._schedule_sweep()
+
+        self.loop.run_until_complete(self._monitor())
+
+        # Only reached via stop().  The watch generator has already exited
+        # normal iteration and cleaned up its native worker; release the pipe
+        # and the loop so the thread finishes with nothing still running
+        self._close()
+        self.loop.close()
+
+    def stop(self) -> None:
+        """Stop the background thread and wait for the thread to finish."""
+        if self.thread is None:
+            return
+
+        self.loop.call_soon_threadsafe(self.stop_event.set)
+        self.thread.join(timeout=10)
+        self.thread = None
+
+    def _schedule_sweep(self) -> None:
+        """Run one sweep, then book the next one on the event loop."""
+        self._sweep_expired()
+        self.loop.call_later(TRACKED_REQUEST_SWEEP_SECONDS, self._schedule_sweep)
+
+    def _sweep_expired(self) -> None:
+        """Free remembered request DNs old enough that no result is coming.
+
+        Entries born before the previous sweep are freed; everything newer
+        survives to the next sweep.  The comment on
+        TRACKED_REQUEST_SWEEP_SECONDS explains the resulting lifetimes.
+        """
+        for conn in list(self.request_dn_table):
+            operation_dn_table = self.request_dn_table[conn]
+            for operation in list(operation_dn_table):
+                _, born_generation = operation_dn_table[operation]
+                if born_generation < self.sweep_generation:
+                    del operation_dn_table[operation]
+            if not operation_dn_table:
+                del self.request_dn_table[conn]
+
+        self.sweep_generation += 1
+
+    async def _monitor(self) -> None:
+        """Open the pipe, then watch the pipe's directory until stopped.
+
+        The directory watch only reacts to the pipe being created or
+        deleted; data arriving is handled by _read() via the event loop.
+        """
+        pipe = str(Path(self.pipe_path).absolute())
+
+        self._open()
+        async for changes in awatch(Path(pipe).parent, stop_event=self.stop_event):
+            for change_type, change_path in changes:
+                if change_path != pipe:
+                    continue
+                match change_type:
+                    case Change.added:
+                        self._open()
+                    case Change.deleted:
+                        self._close()
+
+    def _open(self) -> None:
+        """Open the pipe and ask the event loop to call _read() on new data."""
+        if self.source_fd is not None:
+            return
+
+        # O_RDWR, not O_RDONLY: holding our own write end keeps the pipe's
+        # writer count above zero, so reads never return end of file when
+        # slapd restarts.  Linux-defined behaviour, see fifo(7).
+        try:
+            source_fd = os.open(self.pipe_path, os.O_RDWR | os.O_NONBLOCK)
+        except OSError as error:
+            logging.error(f'Cannot open stats pipe {self.pipe_path}: {error}')
+            return
+
+        if not stat.S_ISFIFO(os.fstat(source_fd).st_mode):
+            logging.error(f'{self.pipe_path} is not a named pipe (FIFO), refusing to read it')
+            os.close(source_fd)
+            return
+
+        self.source_fd = source_fd
+        self.buffer = b''
+
+        # Pipe data is not a filesystem event, so the directory watch never
+        # sees writes; the event loop polls the descriptor for readability
+        if self.loop is not None:
+            self.loop.add_reader(source_fd, self._read)
+
+        logging.info(f'{self.database}: reading slapd stats lines from {self.pipe_path}')
+        self._read()
+
+    def _close(self) -> None:
+        """Close the pipe and forget any half-read line."""
+        if self.source_fd is None:
+            return
+
+        if self.loop is not None:
+            self.loop.remove_reader(self.source_fd)
+        os.close(self.source_fd)
+        self.source_fd = None
+        self.buffer = b''
+        logging.info(f'{self.database}: stats pipe {self.pipe_path} removed, waiting for it to reappear')
+
+    def _read(self) -> None:
+        """Drain everything sitting in the pipe and process complete lines."""
+        if self.source_fd is None:
+            return
+
+        while True:
+            try:
+                data = os.read(self.source_fd, READ_CHUNK_BYTES)
+            except BlockingIOError:
+                break
+            except OSError as error:
+                logging.error(f'{self.database}: error reading stats pipe {self.pipe_path}: {error}')
+                self._close()
+                return
+
+            # End of file means no writer right now.  Keep the descriptor:
+            # a restarted slapd reattaches to the same pipe.
+            if data == b'':
+                break
+
+            self.buffer += data
+            self._drain_buffer()
+
+    def _drain_buffer(self) -> None:
+        """Split the buffer into complete lines and record each one.
+
+        A partial line at the end stays in the buffer until the rest of
+        the line arrives.
+        """
+        while True:
+            line, separator, remainder = self.buffer.partition(b'\n')
+            if separator == b'':
+                break
+            self.buffer = remainder
+            self._record(line.decode('utf-8', errors='replace'))
+
+    def _record(self, line: str) -> None:
+        """Sort one log line to the right handler.
+
+        A result line records timings, a request line remembers the target
+        DN, a connection close line drops that connection's DNs, and
+        anything else is ignored.
+
+        Every stats line lands here, so each regex sits behind a substring
+        gate: `in` runs in C and costs a third of a failed regex search.
+        """
+        if 'qtime=' in line:
+            matched = RESULT_LINE_RE.search(line)
+            if matched:
+                self._record_result(line, matched)
+                return
+
+        # Request tracking only exists to resolve the suffix label
+        if not self.suffixes:
+            return
+
+        if 'base="' in line or 'dn="' in line:
+            matched = REQUEST_LINE_RE.search(line)
+            if matched:
+                self._track_request(matched)
+                return
+
+        if ' closed' in line:
+            matched = CONN_CLOSED_RE.search(line)
+            if matched:
+                self.request_dn_table.pop(int(matched['conn']), None)
+
+    def _record_result(self, line: str, matched: re.Match) -> None:
+        """Record one completed operation's two timings with the metric labels.
+
+        The labels() lookup costs more than the observation, so the handle
+        for each (operation, suffix) pair is cached on first use.  The pair
+        count is small and closed: eight operations times the configured
+        suffixes plus "unknown".
+        """
+        operation = self._operation(line, matched)
+        suffix = self._result_suffix(line)
+
+        children = self.latency_child_table.get((operation, suffix))
+        if children is None:
+            children = (
+                self.queue_histogram.labels(self.database, operation, suffix),
+                self.operation_histogram.labels(self.database, operation, suffix),
+            )
+            self.latency_child_table[(operation, suffix)] = children
+
+        children[0].observe(float(matched['qtime']))
+        children[1].observe(float(matched['etime']))
+
+    def _track_request(self, matched: re.Match) -> None:
+        """Remember the DN a request targets, keyed by connection and operation.
+
+        When a table hits a size cap the oldest entry is evicted rather
+        than letting the table grow without bound.
+        """
+        conn = int(matched['conn'])
+
+        operation_dn_table = self.request_dn_table.get(conn)
+        if operation_dn_table is None:
+            if len(self.request_dn_table) >= TRACKED_CONNECTIONS_MAX:
+                self.request_dn_table.pop(next(iter(self.request_dn_table)))
+            operation_dn_table = {}
+            self.request_dn_table[conn] = operation_dn_table
+
+        if len(operation_dn_table) >= TRACKED_OPERATIONS_PER_CONNECTION_MAX:
+            operation_dn_table.pop(next(iter(operation_dn_table)))
+        operation_dn_table[int(matched['op'])] = (matched['dn'], self.sweep_generation)
+
+    def _result_suffix(self, line: str) -> str:
+        """Find the suffix label for a result line.
+
+        Pops the DN remembered for the result's connection and operation,
+        then returns the longest configured suffix the DN falls under, or
+        "unknown" when nothing was remembered or nothing matches.
+        """
+        if not self.suffixes:
+            return ''
+
+        conn_op = CONN_OP_RE.search(line)
+        if not conn_op:
+            return SUFFIX_UNKNOWN
+
+        operation_dn_table = self.request_dn_table.get(int(conn_op['conn']))
+        entry = operation_dn_table.pop(int(conn_op['op']), None) if operation_dn_table else None
+        if entry is None:
+            return SUFFIX_UNKNOWN
+        dn, _ = entry
+
+        normalized_dn = normalize_dn(dn)
+        for normalized_suffix, display_suffix in self.suffixes:
+            if normalized_dn == normalized_suffix or normalized_dn.endswith(',' + normalized_suffix):
+                return display_suffix
+
+        return SUFFIX_UNKNOWN
+
+    @staticmethod
+    def _operation(line: str, matched: re.Match) -> str:
+        """Name the operation for the label from the result line's tag.
+
+        oid= in place of tag= means an extended operation, and DISCONNECT
+        lines get their own name.
+        """
+        if ' DISCONNECT ' in line:
+            return 'disconnect'
+        if matched['oid'] is not None:
+            return 'extended'
+        return TAG_TO_OPERATION.get(int(matched['tag']), 'other')

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,7 @@ grpcio>=1.47.0
 opencensus-ext-stackdriver==0.8.0
 opencensus-ext-prometheus
 opencensus>=0.11.4
+prometheus-client
 python-ldap
 pyyaml
+watchfiles

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,10 @@ setup(
         'opencensus-ext-stackdriver==0.8.0',
         'opencensus-ext-prometheus',
         'opencensus>=0.11.4',
+        'prometheus-client',
         'python-ldap',
         'pyyaml',
+        'watchfiles',
     ],
     keywords='openldap opencensus metrics',
     entry_points={

--- a/tests/configuration/test_config_transformers.py
+++ b/tests/configuration/test_config_transformers.py
@@ -1,0 +1,91 @@
+# openldap_opencensus_stats
+# Copyright (C) 2026  InkBridge Networks
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Tests for the configuration transformer chain.
+
+The chain talks no LDAP for these configurations: connections are created
+lazily (ReconnectLDAPObject does not connect at construction) and only an
+`object` tree with `children` or name interpolation triggers queries.
+"""
+from openldap_opencensus_stats.config_transformers.base import ConfigurationTransformationChainSingleton
+from openldap_opencensus_stats.config_transformers.snake_case import SnakeCaseConfigurationTransformer
+
+
+def transform(configuration):
+    return ConfigurationTransformationChainSingleton().transform_configuration(configuration)
+
+
+def test_server_without_object_tree():
+    # Regression: a server entry configured only for statsLogPipe defines no
+    # cn=Monitor metrics, and the chain used to raise on the missing object
+    # key (ChildObjectConfigurationTransformer: "All arguments must exist"),
+    # killing the exporter at startup
+    config = {
+        'ldapServers': [
+            {
+                'database': 'transformer-test-pipe-only',
+                'connection': {'serverUri': 'ldap://127.0.0.1:13890/'},
+                'statsLogPipe': {
+                    'pipe': '/run/slapd-stats/stats.pipe',
+                    'suffixes': ['dc=example,dc=org'],
+                },
+            },
+        ],
+    }
+
+    normalized = transform(config)
+
+    server = normalized['ldap_servers'][0]
+    assert server['stats_log_pipe']['pipe'] == '/run/slapd-stats/stats.pipe'
+    assert server['stats_log_pipe']['suffixes'] == ['dc=example,dc=org']
+    assert not server.get('object')
+
+
+def test_sync_only_server_without_object_tree():
+    config = {
+        'ldapServers': [
+            {
+                'database': 'transformer-test-sync-only',
+                'connection': {'serverUri': 'ldap://127.0.0.1:13891/'},
+                'syncOnly': True,
+            },
+        ],
+    }
+
+    normalized = transform(config)
+
+    assert normalized['ldap_servers'][0]['sync_only'] is True
+
+
+def test_snake_case_keys_not_values():
+    config = {
+        'ldapServers': [
+            {
+                'database': 'CamelCaseName',
+                'connection': {'serverUri': 'ldap://host/', 'startTls': False},
+                'statsLogPipe': {'suffixes': ['dc=Example,dc=Org']},
+            },
+        ],
+    }
+
+    snaked = SnakeCaseConfigurationTransformer.process(config)
+
+    server = snaked['ldap_servers'][0]
+    # Keys are converted at every level; values are never touched
+    assert server['database'] == 'CamelCaseName'
+    assert server['connection']['server_uri'] == 'ldap://host/'
+    assert server['connection']['start_tls'] is False
+    assert server['stats_log_pipe']['suffixes'] == ['dc=Example,dc=Org']

--- a/tests/integration/statsLog/exporter.yml
+++ b/tests/integration/statsLog/exporter.yml
@@ -1,0 +1,19 @@
+# Exporter configuration for the logging integration test.
+# No `object` tree: the test only exercises the statsLogPipe latency path,
+# so the poll loop never queries LDAP.  The pipe lives in the docker volume
+# ci.yml shares between this container and the slapd service container.
+ldapServers:
+  - database: citest
+    connection:
+      serverUri: ldap://openldap:389
+    statsLogPipe:
+      pipe: /stats/stats.pipe
+      suffixes:
+        - dc=example,dc=org
+exporters:
+  - name: Prometheus
+    options:
+      namespace: openldap
+      port: 8000
+      address: 127.0.0.1
+period: 5

--- a/tests/integration/statsLog/test_stats_log.py
+++ b/tests/integration/statsLog/test_stats_log.py
@@ -1,0 +1,336 @@
+# openldap_opencensus_stats
+# Copyright (C) 2026  InkBridge Networks
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+End to end test of the statsLogPipe latency path against a real slapd.
+
+The CI workflow (.github/workflows/ci.yml) runs slapd as a service container
+from the stock bitnami OpenLDAP image and creates a named pipe (FIFO) in a
+docker volume both containers share at /stats.  This test then:
+
+1. Starts the exporter, which opens the pipe's read end.
+2. Points the running slapd at the pipe by setting olcLogFile through the
+   cn=config admin, the same way production enables it on a live server.
+   slapd's open of the pipe's write end blocks until a reader exists, so
+   the test first waits for the exporter to hold the read end.
+3. Generates LDAP traffic over the service network (ldap://openldap:389)
+   with python-ldap and asserts the Prometheus metrics reflect it.
+
+Counts are checked as ranges (expected to expected + slack) because slapd
+may perform a small number of internal operations beyond the generated
+traffic.
+"""
+import os
+import re
+import subprocess
+import sys
+import time
+import unittest
+import urllib.error
+import urllib.request
+
+import ldap
+
+TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+RUN_DIR = f'{TEST_DIR}/run'
+PIPE_PATH = '/stats/stats.pipe'
+LDAP_URI = 'ldap://openldap:389'
+ADMIN_DN = 'cn=admin,dc=example,dc=org'
+CONFIG_ADMIN_DN = 'cn=admin,cn=config'
+ADMIN_PW = 'secret'
+METRICS_URL = 'http://127.0.0.1:8000/metrics'
+SUFFIX = 'dc=example,dc=org'
+
+# The traffic generated below, asserted against afterwards.  Every
+# connection performs one bind: 4 admin connections (seed, users, modifies,
+# deletes) plus one per search.
+SEARCH_COUNT = 50
+USER_COUNT = 5
+ADD_COUNT = 7      # 2 seed entries + USER_COUNT users
+MOD_COUNT = 5
+DEL_COUNT = 2
+BIND_COUNT = 54    # SEARCH_COUNT + 4 admin binds
+
+COUNT_SLACK = 5
+READY_DEADLINE_SECONDS = 60
+METRICS_DEADLINE_SECONDS = 30
+
+SAMPLE_RE = re.compile(r'^openldap_(\w+)\{(.*)\} (\S+)$')
+LABEL_RE = re.compile(r'(\w+)="([^"]*)"')
+
+
+def admin_connection():
+    """Connect to the directory server and log in as the admin user."""
+    connection = ldap.initialize(LDAP_URI)
+    connection.simple_bind_s(ADMIN_DN, ADMIN_PW)
+    return connection
+
+
+def fetch_metrics():
+    """Download the exporter's metrics page and unpack it into a dictionary.
+
+    Each metric line becomes one entry, keyed by the metric name plus its
+    labels, holding the metric's numeric value.
+    """
+    body = urllib.request.urlopen(METRICS_URL).read().decode()
+
+    samples = {}
+    for line in body.splitlines():
+        matched = SAMPLE_RE.match(line)
+        if not matched:
+            continue
+        name, labels, value = matched.groups()
+        samples[(name, frozenset(LABEL_RE.findall(labels)))] = float(value)
+    return samples
+
+
+def sample(samples, name, operation, suffix):
+    """Look up one metric value by name, operation, and suffix.
+
+    Returns 0.0 when the exporter has not published a matching metric yet.
+    """
+    labels = frozenset({
+        ('database', 'citest'),
+        ('operation', operation),
+        ('suffix', suffix),
+    })
+    return samples.get((name, labels), 0.0)
+
+
+@unittest.skipUnless(os.path.exists(PIPE_PATH),
+                     'needs the slapd service container and the shared /stats volume, see ci.yml')
+class TestStatsLog(unittest.TestCase):
+    exporter = None
+
+    @classmethod
+    def setUpClass(cls):
+        """Start the exporter and prepare slapd, run once before the test.
+
+        Starts the exporter, waits for the exporter to hold the pipe and
+        serve metrics, waits for slapd to answer, then tells slapd to write
+        its stats lines to the pipe.
+        """
+        os.makedirs(RUN_DIR, exist_ok=True)
+        exporter_bin = os.path.join(os.path.dirname(sys.executable), 'openldap_opencensus_stats')
+        with open(f'{RUN_DIR}/exporter.log', 'wb') as exporter_log:
+            cls.exporter = subprocess.Popen([exporter_bin, f'{TEST_DIR}/exporter.yml'],
+                                            stdout=exporter_log, stderr=subprocess.STDOUT)
+
+        cls.wait_for_pipe_reader()
+        cls.wait_for_metrics_endpoint()
+        cls.wait_for_slapd()
+        cls.enable_stats_logging()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Stop the exporter, run once after the test."""
+        if cls.exporter is not None:
+            cls.exporter.terminate()
+            cls.exporter.wait(timeout=15)
+
+    @staticmethod
+    def wait_for_pipe_reader():
+        """Wait until the exporter has opened the pipe for reading.
+
+        slapd blocks opening the pipe when no reader exists, so the test
+        must not point slapd at the pipe until the exporter holds the read
+        end.  The probe: a non-blocking write open of a named pipe fails
+        with ENXIO until some process has the pipe open for reading, see
+        fifo(7), so the open succeeding is the all-clear.
+        """
+        deadline = time.monotonic() + READY_DEADLINE_SECONDS
+        while True:
+            try:
+                os.close(os.open(PIPE_PATH, os.O_WRONLY | os.O_NONBLOCK))
+                return
+            except OSError:
+                if time.monotonic() >= deadline:
+                    raise
+                time.sleep(1)
+
+    @staticmethod
+    def wait_for_slapd():
+        """Wait until slapd answers an admin login."""
+        deadline = time.monotonic() + READY_DEADLINE_SECONDS
+        while True:
+            try:
+                admin_connection().unbind_s()
+                return
+            except ldap.SERVER_DOWN:
+                if time.monotonic() >= deadline:
+                    raise
+                time.sleep(1)
+
+    @staticmethod
+    def wait_for_metrics_endpoint():
+        """Wait until the exporter serves its metrics page."""
+        deadline = time.monotonic() + READY_DEADLINE_SECONDS
+        while True:
+            try:
+                fetch_metrics()
+                return
+            except urllib.error.URLError:
+                if time.monotonic() >= deadline:
+                    raise
+                time.sleep(1)
+
+    @staticmethod
+    def enable_stats_logging():
+        """Tell the running slapd to write its stats log to the pipe.
+
+        Sets olcLogFile through the config admin, the same change
+        production makes on a live server.  The debug mask that selects
+        the stats lines (-d 256) is already set by the service environment
+        in ci.yml.  Operations before the change are simply not counted,
+        so the traffic below starts from zero.
+        """
+        connection = ldap.initialize(LDAP_URI)
+        connection.simple_bind_s(CONFIG_ADMIN_DN, ADMIN_PW)
+        connection.modify_s('cn=config', [
+            (ldap.MOD_REPLACE, 'olcLogFile', [PIPE_PATH.encode()]),
+        ])
+        connection.unbind_s()
+
+    @staticmethod
+    def wait_for_search_count():
+        """Poll the metrics until every search shows up, then return them.
+
+        Gives up after METRICS_DEADLINE_SECONDS and returns whatever is
+        published, letting the count assertions report the shortfall.
+        """
+        deadline = time.monotonic() + METRICS_DEADLINE_SECONDS
+        while True:
+            samples = fetch_metrics()
+            if sample(samples, 'operation_latency_seconds_count', 'search', SUFFIX) >= SEARCH_COUNT:
+                return samples
+            if time.monotonic() >= deadline:
+                return samples
+            time.sleep(1)
+
+    @staticmethod
+    def seed_directory():
+        """Create the top entry and the ou=people branch the users live under."""
+        connection = admin_connection()
+        connection.add_s(SUFFIX, [
+            ('objectClass', [b'dcObject', b'organization']),
+            ('dc', [b'example']),
+            ('o', [b'Example Org']),
+        ])
+        connection.add_s(f'ou=people,{SUFFIX}', [
+            ('objectClass', [b'organizationalUnit']),
+            ('ou', [b'people']),
+        ])
+        connection.unbind_s()
+
+    @staticmethod
+    def add_users():
+        """Add USER_COUNT test users under ou=people."""
+        connection = admin_connection()
+        for i in range(1, USER_COUNT + 1):
+            connection.add_s(f'uid=user{i},ou=people,{SUFFIX}', [
+                ('objectClass', [b'inetOrgPerson']),
+                ('uid', [f'user{i}'.encode()]),
+                ('cn', [f'User {i}'.encode()]),
+                ('sn', [b'Test']),
+                ('mail', [f'user{i}@example.org'.encode()]),
+            ])
+        connection.unbind_s()
+
+    @staticmethod
+    def run_searches():
+        """Search for a user SEARCH_COUNT times.
+
+        Each search opens a fresh connection and logs in, one bind per
+        search, which is what BIND_COUNT is built from.
+        """
+        for i in range(SEARCH_COUNT):
+            n = (i % USER_COUNT) + 1
+            connection = admin_connection()
+            connection.search_s(SUFFIX, ldap.SCOPE_SUBTREE, f'(uid=user{n})')
+            connection.unbind_s()
+
+    @staticmethod
+    def run_modifies():
+        """Change the mail address of MOD_COUNT users."""
+        connection = admin_connection()
+        for i in range(1, MOD_COUNT + 1):
+            connection.modify_s(f'uid=user{i},ou=people,{SUFFIX}', [
+                (ldap.MOD_REPLACE, 'mail', [f'user{i}-changed@example.org'.encode()]),
+            ])
+        connection.unbind_s()
+
+    @staticmethod
+    def run_deletes():
+        """Delete DEL_COUNT users."""
+        connection = admin_connection()
+        connection.delete_s(f'uid=user4,ou=people,{SUFFIX}')
+        connection.delete_s(f'uid=user5,ou=people,{SUFFIX}')
+        connection.unbind_s()
+
+    @staticmethod
+    def run_unknown_suffix_search():
+        """Search the server's own top entry (the root DSE) anonymously.
+
+        The root DSE sits under no configured suffix, so the timing for
+        both the search and its anonymous bind must land in the
+        suffix="unknown" bucket, which the test asserts on.
+        """
+        connection = ldap.initialize(LDAP_URI)
+        connection.simple_bind_s()
+        connection.search_s('', ldap.SCOPE_BASE, '(objectClass=*)')
+        connection.unbind_s()
+
+    def assert_count(self, samples, operation, expected):
+        """Check one operation's count sits between expected and expected + slack."""
+        value = sample(samples, 'operation_latency_seconds_count', operation, SUFFIX)
+        self.assertGreaterEqual(value, expected, f'{operation}/{SUFFIX} count')
+        self.assertLessEqual(value, expected + COUNT_SLACK, f'{operation}/{SUFFIX} count')
+
+    def test_stats_log(self):
+        """Generate the traffic, then check the published metrics reflect it."""
+        self.seed_directory()
+        self.add_users()
+        self.run_searches()
+        self.run_modifies()
+        self.run_deletes()
+        self.run_unknown_suffix_search()
+
+        samples = self.wait_for_search_count()
+
+        self.assert_count(samples, 'search', SEARCH_COUNT)
+        self.assert_count(samples, 'add', ADD_COUNT)
+        self.assert_count(samples, 'modify', MOD_COUNT)
+        self.assert_count(samples, 'delete', DEL_COUNT)
+        self.assert_count(samples, 'bind', BIND_COUNT)
+
+        # The rootDSE search and its anonymous bind carry no configured suffix
+        self.assertGreaterEqual(
+            sample(samples, 'operation_latency_seconds_count', 'search', 'unknown'), 1)
+
+        # Latency sanity: both timers start at receipt, so summed queue
+        # latency can never exceed summed operation latency, and a local
+        # search should average well under half a second
+        queue_sum = sample(samples, 'queue_latency_seconds_sum', 'search', SUFFIX)
+        operation_sum = sample(samples, 'operation_latency_seconds_sum', 'search', SUFFIX)
+        operation_count = sample(samples, 'operation_latency_seconds_count', 'search', SUFFIX)
+        self.assertLessEqual(queue_sum, operation_sum)
+        self.assertGreater(operation_sum, 0.0)
+        self.assertLess(operation_sum, 60.0)
+        self.assertGreater(operation_count, 0)
+        self.assertLess(operation_sum / operation_count, 0.5)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/statsLog/test_ldap_stats_log_pipe.py
+++ b/tests/statsLog/test_ldap_stats_log_pipe.py
@@ -1,0 +1,184 @@
+# openldap_opencensus_stats
+# Copyright (C) 2026  InkBridge Networks
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Unit tests for the stats log pipe reader, through a real FIFO and the real
+Prometheus exporter.
+
+One exporter serves the whole session (the Prometheus collector registers
+globally, a second would collide), so each test uses its own database label
+and asserts only on its own series.
+
+The synchronous tests drive _open/_read directly.  The event loop test runs
+the real thread, waking on a counter wrapped around _record rather than
+polling, so delivery is observed as an event.
+"""
+import os
+import threading
+import urllib.request
+
+import pytest
+
+from opencensus.ext.prometheus import stats_exporter
+from opencensus.stats import stats
+
+from openldap_opencensus_stats.ldap_stats_log_pipe import LdapStatsLogPipeReader
+
+METRICS_URL = 'http://127.0.0.1:18123/metrics'
+
+SUFFIXES = ['dc=example,dc=org', 'cn=accesslog']
+
+
+class RecordCounter:
+    """Wraps a reader's _record; sets an event once enough lines arrived."""
+
+    def __init__(self, reader, target):
+        self.record = reader._record
+        self.target = target
+        self.seen = 0
+        self.done = threading.Event()
+
+    def __call__(self, line):
+        self.record(line)
+        self.seen += 1
+        if self.seen >= self.target:
+            self.done.set()
+
+
+@pytest.fixture(scope='session')
+def metrics_endpoint():
+    exporter = stats_exporter.new_stats_exporter(
+        stats_exporter.Options(namespace='openldap', port=18123, address='127.0.0.1'))
+    stats.stats.view_manager.register_exporter(exporter)
+    return METRICS_URL
+
+
+@pytest.fixture
+def fifo(tmp_path):
+    path = str(tmp_path / 'stats.pipe')
+    os.mkfifo(path)
+    return path
+
+
+def scrape(url):
+    return urllib.request.urlopen(url).read().decode()
+
+
+def test_pipeline_labels_and_eviction(metrics_endpoint, fifo):
+    reader = LdapStatsLogPipeReader(database='synctest', pipe_path=fifo, suffixes=SUFFIXES)
+    reader._open()
+    assert reader.source_fd is not None
+
+    # Succeeds only because the reader already holds the pipe open, the
+    # same ordering slapd depends on
+    write_fd = os.open(fifo, os.O_WRONLY)
+
+    lines = [
+        # search under the main suffix, DN with case and space variance
+        'conn=1001 op=2 SRCH base="DC=Example, dc=ORG" scope=2 deref=0 filter="(uid=bob)"',
+        'Jul 20 18:00:01 ldap1 slapd[1234]: conn=1001 op=2 SEARCH RESULT tag=101 err=0 '
+        'qtime=0.000012 etime=0.001234 nentries=5 text=',
+        # bind, exact suffix match
+        'conn=1001 op=0 BIND dn="dc=example,dc=org" method=128',
+        'conn=1001 op=0 RESULT tag=97 err=0 qtime=0.000045 etime=0.000210 text=',
+        # modify under the accesslog suffix
+        'conn=1002 op=1 MOD dn="reqStart=20260721000000.000001Z,cn=accesslog"',
+        'conn=1002 op=1 RESULT tag=103 err=0 qtime=0.000100 etime=0.020000 text=',
+        # extended op: no DN-bearing request line -> unknown
+        'conn=1003 op=1 RESULT oid= err=0 qtime=0.000033 etime=0.000900 text=',
+        # request evicted by connection close before its late result -> unknown
+        'conn=1005 op=7 DEL dn="uid=gone,dc=example,dc=org"',
+        'conn=1005 fd=42 closed (connection lost)',
+        'conn=1005 op=7 RESULT tag=107 err=0 qtime=0.000500 etime=0.500000 text=',
+        # DN outside every configured suffix -> unknown
+        'conn=1006 op=1 SRCH base="cn=config" scope=0 deref=0 filter="(objectClass=*)"',
+    ]
+    for line in lines:
+        os.write(write_fd, line.encode() + b'\n')
+
+    # A line split across two writes must be stitched back together
+    split = b'conn=1006 op=1 SEARCH RESULT tag=101 err=0 qtime=0.000009 etime=0.000090 nentries=1 text=\n'
+    os.write(write_fd, split[:40])
+    reader._read()
+    os.write(write_fd, split[40:])
+    reader._read()
+    os.close(write_fd)
+
+    body = scrape(metrics_endpoint)
+    for needle in (
+        'operation_latency_seconds_count{database="synctest",operation="search",suffix="dc=example,dc=org"} 1.0',
+        'queue_latency_seconds_count{database="synctest",operation="bind",suffix="dc=example,dc=org"} 1.0',
+        'operation="modify",suffix="cn=accesslog"',
+        'operation="extended",suffix="unknown"',
+        'operation="delete",suffix="unknown"',
+        'operation_latency_seconds_sum{database="synctest",operation="search",suffix="dc=example,dc=org"} 0.001234',
+        'operation_latency_seconds_sum{database="synctest",operation="search",suffix="unknown"} 9e-05',
+    ):
+        assert needle in body
+
+    # Untimed request lines must never be recorded
+    assert 'SRCH' not in body
+    # The connection close dropped the tracked mapping
+    assert reader.request_dn_table.get(1005) is None
+
+    reader._close()
+
+
+def test_two_pass_sweep(fifo):
+    reader = LdapStatsLogPipeReader(database='sweeptest', pipe_path=fifo, suffixes=SUFFIXES)
+    reader._open()
+    write_fd = os.open(fifo, os.O_WRONLY)
+
+    os.write(write_fd, b'conn=1 op=1 SRCH base="uid=slow,dc=example,dc=org" scope=0 deref=0 filter="(x=y)"\n')
+    reader._read()
+    os.close(write_fd)
+    assert reader.request_dn_table.get(1)
+
+    reader._sweep_expired()
+    assert reader.request_dn_table.get(1), 'first sweep must not reclaim a fresh mapping'
+
+    reader._sweep_expired()
+    assert reader.request_dn_table.get(1) is None, 'second sweep must reclaim the mapping'
+
+    reader._close()
+
+
+def test_event_loop_delivery(metrics_endpoint, fifo):
+    reader = LdapStatsLogPipeReader(database='threadtest', pipe_path=fifo, suffixes=SUFFIXES)
+    counter = RecordCounter(reader, target=40)
+    reader._record = counter
+    reader.start()
+
+    # The reader thread must be joined before the interpreter exits, or
+    # teardown kills it mid native call and the process can dump core
+    try:
+        # Blocks until the reader thread has the pipe open
+        write_fd = os.open(fifo, os.O_WRONLY)
+        for i in range(20):
+            line = (f'conn=2000 op={i} SRCH base="dc=example,dc=org" scope=2 deref=0 filter="(uid=u{i})"\n'
+                    f'conn=2000 op={i} SEARCH RESULT tag=101 err=0 qtime=0.000010 etime=0.000500 nentries=1 text=\n')
+            os.write(write_fd, line.encode())
+        os.close(write_fd)
+
+        assert counter.done.wait(timeout=15), \
+            f'event loop delivered {counter.seen} of {counter.target} lines'
+    finally:
+        reader.stop()
+
+    assert reader.thread is None
+
+    body = scrape(metrics_endpoint)
+    assert ('operation_latency_seconds_count{database="threadtest",operation="search",'
+            'suffix="dc=example,dc=org"} 20.0') in body


### PR DESCRIPTION
## What

Adds a `statsLogPipe` option to `ldapServers` entries. When set, the service reads slapd's stats log lines from a named pipe (FIFO) and publishes operation latency histograms (`openldap_queue_latency_seconds`, `openldap_operation_latency_seconds`, labelled by `database`, `operation`, and optionally directory `suffix`) on the same Prometheus endpoint as the existing cn=Monitor statistics. The timing data never touches disk, and no second daemon or port is needed. The histograms record directly into prometheus_client rather than through OpenCensus: OpenCensus deep-copies its accumulated view state on every record call, capping a reader thread near 10k results/sec, while direct histogram observation sustains ~250k results/sec on the same hardware (a reader that cannot keep up fills the 64KiB pipe and stalls slapd's worker threads). The trade is that these two metrics never reach the Stackdriver exporter.

## Why

cn=Monitor has no latency data at all, only counters, so this exporter currently cannot answer "how slow are queries". slapd does produce latency: every completed operation logs one RESULT line with `qtime` (thread pool queue wait) and `etime` (wall clock time from receipt of the operation until its result was sent, so etime includes qtime), compiled in by default via `SLAP_STATS_ETIME` ([slap.h#L82-L83](https://github.com/openldap/openldap/blob/45c7590378c60120e9ba3295ba1f223ceffa1de9/servers/slapd/slap.h#L82-L83), [result.c#L40-L55](https://github.com/openldap/openldap/blob/45c7590378c60120e9ba3295ba1f223ceffa1de9/servers/slapd/result.c#L40-L55)). Those lines are the only latency source slapd has.

## Design

The pipe handling deliberately mirrors the `PipeReader` in openldap-audit2json (Ethan's code), which already runs the same slapd-to-FIFO handoff in production for the audit log:

- The FIFO is opened `O_RDWR|O_NONBLOCK` and held open. Holding our own write end means reads never return end of file across slapd restarts (Linux-defined, fifo(7)). slapd's own logfile open is a plain blocking `open()` ([logging.c#L261](https://github.com/openldap/openldap/blob/45c7590378c60120e9ba3295ba1f223ceffa1de9/servers/slapd/logging.c#L261)), so on a FIFO slapd waits until a reader exists: this service must start first and stay up, which it already does.
- The event loop polls the descriptor (`loop.add_reader`) and drains the pipe whenever data arrives. Data moving through a pipe is not a filesystem event, so a watchfiles/inotify monitor cannot see writes; the Integration workflow caught exactly that. (audit2json's path-watching works because slapo-auditlog reopens its log file around every entry; slapd holds its stats logfile open.)
- A watchfiles monitor on the pipe's directory handles lifecycle only: pipe appearing opens, deletion closes.
- Reader failure is safe for the directory: slapd ignores SIGPIPE ([main.c#L744-L745](https://github.com/openldap/openldap/blob/45c7590378c60120e9ba3295ba1f223ceffa1de9/servers/slapd/main.c#L744-L745)) and discards logging write errors, so a dead reader only costs metrics.

Operation labels come from the `tag=` value on the RESULT line (result tags per [ldap.h#L536-L547](https://github.com/openldap/openldap/blob/45c7590378c60120e9ba3295ba1f223ceffa1de9/include/ldap.h#L536-L547)); extended operation results carry `oid=` instead and are labelled `extended`.

The README section documents the slapd side (LDIF for `olcLogFile`/`olcLogLevel`, the non-persistent `monitorDebugLevel` routing, why `olcLogFileOnly` and `olcLogFileRotate` must not be set) plus the known data gaps (abandoned operations never log a RESULT line, [result.c#L643-L657](https://github.com/openldap/openldap/blob/45c7590378c60120e9ba3295ba1f223ceffa1de9/servers/slapd/result.c#L643-L657)).

### Suffix labelling

RESULT lines carry no DN, but every operation first logs a request line with the target DN under the same `conn=`/`op=` prefix (`SRCH base="..."` at [search.c#L236-L239](https://github.com/openldap/openldap/blob/45c7590378c60120e9ba3295ba1f223ceffa1de9/servers/slapd/search.c#L236-L239), `dn="..."` equivalents for bind/add/mod/modrdn/del/cmp). When `statsLogPipe` is a mapping with a `suffixes` list, the reader keeps a (conn, op) to DN table from request lines and labels each timing with the longest configured suffix the DN falls under. Entries are reclaimed three ways: the RESULT pops them, the connection close line drops them, and an hourly two pass generational sweep frees mappings for operations that never complete (abandons, persistent searches), which therefore live at least one hour and at most two; the table is also hard-capped. Unattributable results (extended operations log no DN; operations already in flight at reader start) are labelled `unknown`. Without `suffixes` the label is empty and no tracking happens.

## Testing

- flake8 clean with the CI settings.
- Smoke test on macOS (reader driven synchronously, since the watchfiles trigger is inotify behaviour): FIFO open ordering, parsing of search/bind/modify/extended lines including a line split across two pipe writes, suffix matching with case and whitespace variance, eviction on connection close, unknown buckets, untimed lines ignored, and the Prometheus endpoint serving correctly labelled histograms with exact sums. All pass.
- The CI workflow (added in this PR) runs the whole path end to end on the self-hosted runners: slapd runs as a service container from the stock bitnami OpenLDAP image, the FIFO is shared through a docker volume, and the test sets `olcLogFile` on the running server through the cn=config admin (the same way production enables it) before generating traffic and asserting on per-operation counts, suffix labels, and latency sums. Green: 50/50 searches, all op types labelled.

Deployment wiring (mkfifo drop-in, SELinux fifo_file policy, salt state) is estate-side and will follow in the infrastructure repo, matching the existing `openldap_audit2json` state.



