### PR TITLE
Installation of grpcio and opencensus-ext-stackdriver should be optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ monitoring software, such as GCP.
 sudo pip3 install openldap-opencensus-stats
 ```
 
+The Stackdriver exporter depends on `grpcio`, which is packaged as an
+optional extra rather than part of the default install. Deployments that
+only use the Prometheus exporter can ignore this; anyone who needs the
+Stackdriver exporter should install with:
+```bash
+sudo pip3 install openldap-opencensus-stats[stackdriver]
+```
+
 ### Configuration
 A sample configuration file is provided in openldap-opencensus-stats.template.yml.  The
 configuration is YAML data, with the structure described below.
@@ -95,7 +103,8 @@ exporters:
 Each entry will have the structure:
 - **name** _(required)_: The name of the exporter.  Currently only two names
   are supported, `Stackdriver` to export to GCP, and `Prometheus`, which
-  is mostly useful for development or debugging.
+  is mostly useful for development or debugging.  Using `Stackdriver`
+  requires installing the `stackdriver` extra (see Installation above).
 - **options** _(required)_: The options for instantiating the exporter.
   The contents will vary depending on the chosen exporter.
   - **project_id** _(required for Stackdriver)_: The GCP project ID

--- a/openldap_opencensus_stats/configuration.py
+++ b/openldap_opencensus_stats/configuration.py
@@ -14,7 +14,6 @@ from openldap_opencensus_stats.ldap_stats_log_pipe import LdapStatsLogPipeReader
 
 from opencensus.stats import stats
 from opencensus.ext.prometheus import stats_exporter
-import opencensus.ext.stackdriver.stats_exporter
 
 # Make up for broken code in the Prometheus exporter
 import opencensus.stats.aggregation_data
@@ -163,6 +162,10 @@ def create_exporter(exporter_configuration=None):
         )
 
     elif "Stackdriver" == name:
+        # Imported here, not at module level: opencensus-ext-stackdriver and its
+        # grpcio dependency are optional (see setup.py's "stackdriver" extra),
+        # so this module must not import them unconditionally.
+        import opencensus.ext.stackdriver.stats_exporter
         exporter = opencensus.ext.stackdriver.stats_exporter.new_stats_exporter(interval=5)
         print(f"Exporting stats to this project {exporter.options.project_id}")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,11 @@
-grpcio>=1.47.0
-opencensus-ext-stackdriver==0.8.0
 opencensus-ext-prometheus
 opencensus>=0.11.4
 prometheus-client
 python-ldap
 pyyaml
 watchfiles
+
+# Only needed for the Stackdriver exporter, and installed optionally via
+# setup.py's "stackdriver" extra rather than as part of the default install.
+# grpcio>=1.47.0
+# opencensus-ext-stackdriver==0.8.0

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,6 @@ setup(
     license='AGPL 3.0',
     packages=find_packages(),
     install_requires=[
-        'grpcio>=1.47.0',
-        'opencensus-ext-stackdriver==0.8.0',
         'opencensus-ext-prometheus',
         'opencensus>=0.11.4',
         'prometheus-client',
@@ -24,6 +22,16 @@ setup(
         'pyyaml',
         'watchfiles',
     ],
+    extras_require={
+        # grpcio (opencensus-ext-stackdriver's own dependency) is optional;
+        # deployments that only use the Prometheus exporter don't need it.
+        # pip install openldap-opencensus-stats[stackdriver] pulls this in
+        # for anyone who does need the Stackdriver exporter.
+        'stackdriver': [
+            'grpcio>=1.47.0',
+            'opencensus-ext-stackdriver==0.8.0',
+        ],
+    },
     keywords='openldap opencensus metrics',
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Dependencies grpcio and opencensus-ext-stackdriver are only for exporter Stackdriver, so we don't need to install them if we use another exporter (e.g. Prometheus).